### PR TITLE
Update IM_SIZE in the notebook

### DIFF
--- a/training-and-serving-with-tf-keras.ipynb
+++ b/training-and-serving-with-tf-keras.ipynb
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "import tensorflow as tf\n",
-    "IM_SIZE = 16 # image size\n",
+    "IM_SIZE = 128 # image size\n",
     "\n",
     "image_input = tf.keras.Input(shape=(IM_SIZE, IM_SIZE, 3), name='input_layer')\n",
     "\n",


### PR DESCRIPTION
`IM_SIZE` is 128 in your [blog](https://medium.com/tensorflow/training-and-serving-ml-models-with-tf-keras-fd975cc0fa27) but it is 16 here. So, just for the sake of consistency, I think it should be update here.

Thank you!